### PR TITLE
Fix: Update deployment workflow to build image from GitHub source

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,9 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Deploy Docker container
+      - name: Build and deploy container
         uses: azure/webapps-deploy@v2
         with:
           app-name: reddit-sentiment-bot
-          images: reddit-sentiment-bot
+          slot-name: production
+          package: .


### PR DESCRIPTION
Summary:
This PR removes the images: directive from the GitHub Actions deployment workflow. Azure was attempting to pull a Docker image named reddit-sentiment-bot from Docker Hub, which does not exist, resulting in a failed startup.

Changes:

Removed images: field from azure/webapps-deploy@v2 step

Added package: . to build and deploy container from repo source

Why this matters:
Azure App Service is expected to build the container using the Dockerfile in the GitHub repo, not pull it from a remote registry. This change ensures successful deployment from GitHub Actions to Azure.

Test Plan:

Confirmed via log stream that Azure no longer attempts a Docker Hub pull

Deployment process now builds from local repo and starts cleanly