### PR TITLE
Add minimal Flask healthcheck to satisfy Azure App Service container requirements

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ import praw
 import pandas as pd
 import yfinance as yf
 import gspread
+from flask import Flask
 from google.oauth2.service_account import Credentials
 from dotenv import load_dotenv
 
@@ -23,55 +24,77 @@ import functions as f
 
 
 
-load_dotenv()
-reddit = praw.Reddit(
-    client_id = os.getenv("REDDIT_CLIENT_ID"),
-    client_secret = os.getenv("REDDIT_CLIENT_SECRET"),
-    user_agent = os.getenv("REDDIT_USER_AGENT"),
-)
-openai_api_key = os.getenv("OPENAI_API_KEY") #set openai api_key
-openai_client = openai.OpenAI(api_key=openai_api_key)  # Initialize OpenAI client
-email_list = ["josephmichaelmanning@gmail.com"] # Email list
-email_password = os.getenv("GOOGLE_APP_PASS") # Main gmail app pass
 
-scopes = ["https://www.googleapis.com/auth/spreadsheets", 
-          "https://www.googleapis.com/auth/drive"]
+app = Flask(__name__)
 
-if os.getenv("GOOGLE_CREDS_JSON"):
-    creds_json = os.getenv("GOOGLE_CREDS_JSON")
-    creds_dict = json.loads(creds_json)
-    creds = Credentials.from_service_account_info(creds_dict, scopes=scopes)
-else:
-    google_creds_path = os.getenv("GOOGLE_CREDS_PATH",
+@app.route("/")
+def healthcheck():
+    return "Bot is running!"
 
-google_sheets_client = gspread.authorize(creds)
-# Open Google Sheet
-sheet = google_sheets_client.open("RedditBotLogs").sheet1  # Adjust for multiple sheets
-# Append data
-data = ["Timestamp", "Ticker", "Title", "Sentiment", "Yesterday Close", "Current Price", "Percent Change", "URL"]
+def run_bot():
 
-
-# Create a list to store threads
-threads = []
-
-# Start a thread for each subreddit
-for sub in subreddits:
-    thread = threading.Thread(
-        target=f.monitor_subreddit,
-            args=(
-                sub,
-                ticker_keywords,
-                reddit,
-                sheet,              # ✅ Google Sheets object
-                openai_client,      # ✅ Initialized OpenAI client instance
-                email_list,
-                email_password
-        )
+    
+    
+    load_dotenv()
+    reddit = praw.Reddit(
+        client_id = os.getenv("REDDIT_CLIENT_ID"),
+        client_secret = os.getenv("REDDIT_CLIENT_SECRET"),
+        user_agent = os.getenv("REDDIT_USER_AGENT"),
     )
-    thread.daemon = True  # Ensures the thread shuts down if the main program exits
-    thread.start()
-    threads.append(thread)
+    openai_api_key = os.getenv("OPENAI_API_KEY") #set openai api_key
+    openai_client = openai.OpenAI(api_key=openai_api_key)  # Initialize OpenAI client
+    email_list = ["josephmichaelmanning@gmail.com"] # Email list
+    email_password = os.getenv("GOOGLE_APP_PASS") # Main gmail app pass
+    
+    scopes = ["https://www.googleapis.com/auth/spreadsheets", 
+              "https://www.googleapis.com/auth/drive"]
+    
+    if os.getenv("GOOGLE_CREDS_JSON"):
+        creds_json = os.getenv("GOOGLE_CREDS_JSON")
+        creds_dict = json.loads(creds_json)
+        creds = Credentials.from_service_account_info(creds_dict, scopes=scopes)
+    else:
+        google_creds_path = os.getenv("GOOGLE_CREDS_PATH", "./GoogleAPI.json")
+        creds = Credentials.from_service_account_file(google_creds_path, scopes=scopes)
 
-# Keep the main script alive
-for thread in threads:
-    thread.join()
+    
+    google_sheets_client = gspread.authorize(creds)
+    # Open Google Sheet
+    sheet = google_sheets_client.open("RedditBotLogs").sheet1  # Adjust for multiple sheets
+    # Append data
+    data = ["Timestamp", "Ticker", "Title", "Sentiment", "Yesterday Close", "Current Price", "Percent Change", "URL"]
+    
+    
+    # Create a list to store threads
+    threads = []
+    print("Starting bot...")
+    
+    # Start a thread for each subreddit
+    for sub in subreddits:
+        thread = threading.Thread(
+            target=f.monitor_subreddit,
+                args=(
+                    sub,
+                    ticker_keywords,
+                    reddit,
+                    sheet,              # ✅ Google Sheets object
+                    openai_client,      # ✅ Initialized OpenAI client instance
+                    email_list,
+                    email_password
+            )
+        )
+        thread.daemon = True  # Ensures the thread shuts down if the main program exits
+        thread.start()
+        threads.append(thread)
+    
+    # Keep the main script alive
+    for thread in threads:
+        thread.join()
+
+
+
+if __name__ == "__main__":
+    threading.Thread(target=run_bot).start()
+    print("Flask server started.")
+    app.run(host="0.0.0.0", port=5000)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ yfinance
 gspread
 google-auth
 python-dotenv
+flask


### PR DESCRIPTION
This PR introduces a lightweight Flask healthcheck route to support running the Reddit sentiment bot in Azure App Service. Azure requires that containers respond to HTTP pings on a designated port (default: 5000) to remain active. Since the bot is designed as a background service with no native HTTP interface, this workaround ensures continuous uptime without impacting core functionality.


Added flask to requirements.txt

Wrapped run_bot() in a thread so it runs concurrently with Flask

Created a simple @app.route("/") to return a "Bot is running!" message

Added print() statements to assist in log visibility during container start

Preserved existing logic and .env handling without altering the bot's behavior

----



Azure App Service shuts down containers that don't respond to port 5000 pings

This ensures the container passes Azure's health checks while maintaining the bot’s architecture

This pattern is a known and accepted solution when hosting non-web workloads in web-first platforms like App Service